### PR TITLE
인증 객체와 도메인 유저(UserEntity) 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 .env
+*.env
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/src/main/java/com/goormitrip/goormitrip/GoormitripApplication.java
+++ b/src/main/java/com/goormitrip/goormitrip/GoormitripApplication.java
@@ -8,12 +8,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import com.goormitrip.goormitrip.product.domain.Product;
 import com.goormitrip.goormitrip.product.domain.ProductStatus;
 import com.goormitrip.goormitrip.product.repository.ProductRepository;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@EnableJpaAuditing
 public class GoormitripApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/goormitrip/goormitrip/global/security/CustomUserDetails.java
+++ b/src/main/java/com/goormitrip/goormitrip/global/security/CustomUserDetails.java
@@ -16,6 +16,10 @@ public class CustomUserDetails implements UserDetails {
 		this.user = user;
 	}
 
+	public UserEntity getUser() {
+		return user;
+	}
+
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
 		return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole()));

--- a/src/main/java/com/goormitrip/goormitrip/global/security/CustomUserDetails.java
+++ b/src/main/java/com/goormitrip/goormitrip/global/security/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.goormitrip.goormitrip.global.security;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.goormitrip.goormitrip.user.domain.UserEntity;
+
+public class CustomUserDetails implements UserDetails {
+	private final UserEntity user;
+
+	public CustomUserDetails(UserEntity user) {
+		this.user = user;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return UserDetails.super.isAccountNonExpired();
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return UserDetails.super.isAccountNonLocked();
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return UserDetails.super.isCredentialsNonExpired();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return UserDetails.super.isEnabled();
+	}
+}

--- a/src/main/java/com/goormitrip/goormitrip/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/goormitrip/goormitrip/global/security/JwtTokenProvider.java
@@ -1,0 +1,10 @@
+package com.goormitrip.goormitrip.global.security;
+
+import com.goormitrip.goormitrip.user.domain.UserRole;
+
+public interface JwtTokenProvider {
+	String createAccessToken(Long userId, UserRole role);
+	String createRefreshToken(Long userId);
+	boolean isValid(String token);
+	Long extractUserId(String token);
+}

--- a/src/main/java/com/goormitrip/goormitrip/global/security/JwtUtils.java
+++ b/src/main/java/com/goormitrip/goormitrip/global/security/JwtUtils.java
@@ -20,10 +20,10 @@ public class JwtUtils {
 
 	private SecretKey key;
 
-	@Value("${app.jwt.secret}")
+	@Value("${JWT_SECRET_KEY}")
 	private String jwtSecret;
 
-	@Value("${app.jwt.expiration}")
+	@Value("${app.jwt.expiration:1800000}")
 	private long jwtExpiration;
 
 	@PostConstruct

--- a/src/main/java/com/goormitrip/goormitrip/global/util/BaseTimeEntity.java
+++ b/src/main/java/com/goormitrip/goormitrip/global/util/BaseTimeEntity.java
@@ -1,6 +1,6 @@
 package com.goormitrip.goormitrip.global.util;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -17,5 +17,5 @@ public abstract class BaseTimeEntity {
 
 	@CreatedDate
 	@Column(nullable = false, updatable = false)
-	private Instant createdAt;
+	private LocalDateTime createdAt;
 }

--- a/src/main/java/com/goormitrip/goormitrip/global/util/BaseTimeEntity.java
+++ b/src/main/java/com/goormitrip/goormitrip/global/util/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.goormitrip.goormitrip.global.util;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private Instant createdAt;
+}

--- a/src/main/java/com/goormitrip/goormitrip/user/domain/UserEntity.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/domain/UserEntity.java
@@ -4,15 +4,13 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.hibernate.annotations.CreationTimestamp;
-
-import java.time.LocalDateTime;
+import com.goormitrip.goormitrip.global.util.BaseTimeEntity;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "users")
-public class UserEntity {
+public class UserEntity extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,9 +26,6 @@ public class UserEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private UserRole role = UserRole.USER;
-
-	@CreationTimestamp
-	private LocalDateTime createdAt;
 }
 
 

--- a/src/main/java/com/goormitrip/goormitrip/user/domain/UserEntity.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/domain/UserEntity.java
@@ -37,10 +37,6 @@ public class UserEntity implements UserDetails {
 	@CreationTimestamp
 	private LocalDateTime createdAt;
 
-	public enum UserRole {
-		USER, ADMIN
-	}
-	
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
 		return Collections.singletonList(new SimpleGrantedAuthority(("ROLE_" + role.name())));

--- a/src/main/java/com/goormitrip/goormitrip/user/domain/UserEntity.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/domain/UserEntity.java
@@ -5,19 +5,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
-import java.util.*;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "users")
-
-public class UserEntity implements UserDetails {
+public class UserEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,37 +31,6 @@ public class UserEntity implements UserDetails {
 
 	@CreationTimestamp
 	private LocalDateTime createdAt;
-
-	@Override
-	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return Collections.singletonList(new SimpleGrantedAuthority(("ROLE_" + role.name())));
-	}
-
-	@Override
-	public String getUsername() {
-		return email;
-	}
-
-	@Override
-	public boolean isAccountNonExpired() {
-		return true;
-	}
-
-	@Override
-	public boolean isAccountNonLocked() {
-		return true;
-	}
-
-	@Override
-	public boolean isCredentialsNonExpired() {
-		return true;
-	}
-
-	@Override
-	public boolean isEnabled() {
-		return true;
-	}
-
 }
 
 

--- a/src/main/java/com/goormitrip/goormitrip/user/domain/UserRole.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/domain/UserRole.java
@@ -1,0 +1,5 @@
+package com.goormitrip.goormitrip.user.domain;
+
+public enum UserRole {
+	USER, ADMIN
+}

--- a/src/main/java/com/goormitrip/goormitrip/user/service/AuthService.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/service/AuthService.java
@@ -45,6 +45,7 @@ public class AuthService {
 
         userRepository.save(user);
 
+        // 회원가입 후 인증 처리 없이도 JWT 생성 가능
         // Authentication authentication = authenticationManager.authenticate(
         //     new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
         // );
@@ -62,13 +63,11 @@ public class AuthService {
             new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
         );
 
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        UserEntity user = userDetails.getUser();
 
-        UserDetails userDetails = (UserDetails)authentication.getPrincipal();
         String jwt = jwtUtils.generateToken(userDetails);
-
-        UserEntity user = userRepository.findByEmail(request.getEmail())
-            .orElseThrow(() -> new RuntimeException("이메일 또는 비밀번호가 잘못되었습니다."));
+        // SecurityContextHolder.getContext().setAuthentication(authentication);
 
         return new AuthResponse(jwt, user.getEmail(), user.getRole().name());
     }

--- a/src/main/java/com/goormitrip/goormitrip/user/service/AuthService.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.goormitrip.goormitrip.user.service;
 
+import com.goormitrip.goormitrip.global.security.CustomUserDetails;
 import com.goormitrip.goormitrip.user.domain.UserEntity;
 import com.goormitrip.goormitrip.user.domain.UserRole;
 import com.goormitrip.goormitrip.user.dto.AuthRequest;
@@ -44,13 +45,13 @@ public class AuthService {
 
         userRepository.save(user);
 
-        Authentication authentication = authenticationManager.authenticate(
-            new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
-        );
+        // Authentication authentication = authenticationManager.authenticate(
+        //     new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+        // );
 
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        // SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        UserDetails userDetails = (UserDetails)authentication.getPrincipal();
+        CustomUserDetails userDetails = new CustomUserDetails(user);
         String jwt = jwtUtils.generateToken(userDetails);
 
         return new AuthResponse(jwt, user.getEmail(), user.getRole().name());

--- a/src/main/java/com/goormitrip/goormitrip/user/service/AuthService.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.goormitrip.goormitrip.user.service;
 
 import com.goormitrip.goormitrip.user.domain.UserEntity;
+import com.goormitrip.goormitrip.user.domain.UserRole;
 import com.goormitrip.goormitrip.user.dto.AuthRequest;
 import com.goormitrip.goormitrip.user.dto.AuthResponse;
 import com.goormitrip.goormitrip.user.dto.SignupRequest;
@@ -39,7 +40,7 @@ public class AuthService {
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setPhone(request.getPhone());
-        user.setRole(UserEntity.UserRole.USER);
+        user.setRole(UserRole.USER);
 
         userRepository.save(user);
 

--- a/src/main/java/com/goormitrip/goormitrip/user/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/goormitrip/goormitrip/user/service/UserDetailsServiceImpl.java
@@ -5,6 +5,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.goormitrip.goormitrip.global.security.CustomUserDetails;
+import com.goormitrip.goormitrip.user.domain.UserEntity;
 import com.goormitrip.goormitrip.user.repository.UserRepository;
 
 @Service
@@ -18,8 +20,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
 	@Override
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-		return userRepository.findByEmail(email)
+		final UserEntity user = userRepository.findByEmail(email)
 			.orElseThrow(() -> new UsernameNotFoundException("이메일 또는 비밀번호를 확인해주세요."));
+		return new CustomUserDetails(user);
 	}
-
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,12 @@ spring:
     username: ${DEV_DATASOURCE_USERNAME}
     password: ${DEV_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+logging:
+  level:
+    root: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,3 +4,6 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,6 @@ spring:
 
   jpa:
     show-sql: true
-    hibernate:
-      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   application:
     name: goormitrip
-
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:prod}
 
@@ -15,3 +14,4 @@ spring:
 app:
   jwt:
     secret: ${JWT_SECRET_KEY}
+    expiration: 1800000


### PR DESCRIPTION
# 설명

- 기존 `UserEntity`가 Spring Security 인증 주체 역할(`UserDetails`)까지 담당하고 있었으나, 이는 단일 책임 원칙(SRP)을 위반하고 유지보수에 불리하다고 판단.
- 인증 로직과 도메인 모델의 책임을 분리하여, 인증 객체와 도메인 유저(Entity)를 분리하였습니다.

### 🔧 주요 변경 사항
- `UserRole` 클래스를 별도 Enum 또는 도메인 모듈로 이동
- `UserEntity`에서 Spring Security 관련 구현 제거 (`UserDetails`, `getAuthorities` 등)
- 인증 전용 객체(`CustomUserPrincipal` 등)를 별도로 정의하여 SecurityContext에서 사용
- 기존 인증 로직에서 `UserEntity`를 직접 의존하던 부분 수정
- `BaseTimeEntity`를 생성하여 `createdAt`, `updatedAt`의 공통 처리 분리
- `application-dev.yml`, `application-prod.yml`에서 DDL과 logging 설정 분리
- `.env` 관련 ignore 추가
